### PR TITLE
[bugfix-navbar] Portifolio item not working

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,7 +140,7 @@
                     </div>
                 </div>
             </section>
-            <section class="portifolio">
+            <section class="portifolio" id="portifolio">
                 <div class="conteudo">
                     <h1>Portifólio</h1>
                     <projetos :dados="projetos"></projetos>


### PR DESCRIPTION
The portfolio's navbar item wasn't working correctly because the section portifolio wasn't with the id.